### PR TITLE
Multithreaded rendering

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -961,7 +961,9 @@ void MainWindow::newFFTData(float *fft_data, int fftsize)
         }
 
     }
-    ui->plotterFrame->setNewFftData(_iirFftData, _realFftData, fftsize);
+    //ui->plotterFrame->setNewFftData(_iirFftData, _realFftData, fftsize);
+
+    QtConcurrent::run(ui->plotterFrame, &CPlotter::setNewFftData, _iirFftData, _realFftData, fftsize);
 }
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -32,6 +32,7 @@
 #include <QToolTip>
 #include <QShortcut>
 #include <QAudioDeviceInfo>
+#include <QtConcurrent/QtConcurrent>
 #include <math.h>
 #include <complex>
 #include <libconfig.h++>

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -916,7 +916,7 @@ void CPlotter::resizeEvent(QResizeEvent* )
 void CPlotter::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
-
+    m_drawMutex.lock();
     painter.setOpacity(1.0);
     painter.drawPixmap(0, 0, m_2DPixmap);
     painter.setOpacity(0.75);
@@ -925,6 +925,7 @@ void CPlotter::paintEvent(QPaintEvent *)
     painter.setOpacity(1.0);
     painter.drawPixmap(0, m_Percent2DScreen * m_Size.height() / 100,
                        m_WaterfallPixmap);
+    m_drawMutex.unlock();
 }
 
 // Called to update spectrum data for displaying on the screen

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -128,6 +128,7 @@ signals:
     void newFilterFreq(qint64 low, qint64 high);  /* substitute for NewLow / NewHigh */
     void pandapterRangeChanged(float min, float max);
     void newZoomLevel(float level);
+    void updatePlotter();
 
 public slots:
     // zoom functions
@@ -286,6 +287,7 @@ private:
     QPoint      LineBuf[MAX_SCREENSIZE];
     QBrush      m_fftBrush;
     bool        m_ColourFFT;
+    QMutex      m_drawMutex;
 
 };
 


### PR DESCRIPTION
Render FFT and waterfall images on a different thread
    
This improves CPU usage on main thread where UI interaction happens.
Also prevents unusable UI when too many polygon lines have to be drawn.