### PR TITLE
dmr: add explicit cstdint import

### DIFF
--- a/src/DMR/constants.h
+++ b/src/DMR/constants.h
@@ -1,6 +1,8 @@
 #ifndef DMRCONSTANTS_H
 #define DMRCONSTANTS_H
 
+#include <cstdint>
+
 #include <gnuradio/gr_complex.h>
 #include "src/MMDVM/DMRDefines.h"
 


### PR DESCRIPTION
An upstream change removed the cstdint import from a couple files, causing it to no longer be included as a side-effect of other includes.

https://gcc.gnu.org/pipermail/gcc-patches/2024-August/659176.html