### PR TITLE
qmake: find protobuf via pkg-config

### DIFF
--- a/qradiolink.pro
+++ b/qradiolink.pro
@@ -297,6 +297,9 @@ INCLUDEPATH += $$_PRO_FILE_PWD_/src/MMDVM/
 #CONFIG += link_pkgconfig
 #PKGCONFIG += gnuradio
 
+CONFIG += link_pkgconfig
+PKGCONFIG += protobuf
+
 FORMS    += src/mainwindow.ui
 
 
@@ -305,7 +308,7 @@ LIBS += -lgnuradio-pmt -lgnuradio-analog -lgnuradio-fft -lgnuradio-vocoder -lgnu
         -lgnuradio-blocks -lgnuradio-filter -lgnuradio-digital -lgnuradio-runtime -lgnuradio-fec \
         -lboost_system$$BOOST_SUFFIX
 LIBS += -lrt -lpthread # need to include on some distros
-LIBS += -lprotobuf -lopus -lcodec2 -ljpeg -lconfig++ -lspeexdsp -lftdi -lsndfile -llog4cpp -lLimeSuite -lzmq -ldl
+LIBS += -lopus -lcodec2 -ljpeg -lconfig++ -lspeexdsp -lftdi -lsndfile -llog4cpp -lLimeSuite -lzmq -ldl
 LIBS += -lSoapySDR
 
 


### PR DESCRIPTION
Protobuf depends on a bunch of libraries from abseil, among other dependencies.